### PR TITLE
[FIX] sale: Wrong filter definition

### DIFF
--- a/addons/sale/report/sale_report_view.xml
+++ b/addons/sale/report/sale_report_view.xml
@@ -49,7 +49,7 @@
                 <field name="date"/>
                 <field name="date_confirm"/>
                 <filter string="This Year" name="year" invisible="1" domain="[('date','&lt;=', time.strftime('%%Y-12-31')),('date','&gt;=',time.strftime('%%Y-01-01'))]"/>
-                <filter name="Quotations" domain="[('state','in',('draft'))]"/>
+                <filter name="Quotations" domain="[('state','=','draft')]"/>
                 <filter name="Sales" string="Sales" domain="[('state','not in',('draft', 'cancel'))]"/>
                 <separator/>
                 <filter string="My Sales" help="My Sales" domain="[('user_id','=',uid)]"/>


### PR DESCRIPTION
'state', 'in', ('draft') is an invalid definition, ('draft') is not a tuple
should have been ('draft',)

Replacing by simpler 'state', '=', 'draft'

Fixes #8115
Closes #9016