### PR TITLE
[FIX] stock: speed up backorder creation in barcode ui

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -1490,7 +1490,7 @@ class stock_picking(osv.osv):
         #write qty_done into field product_qty for every package_operation before doing the transfer
         pack_op_obj = self.pool.get('stock.pack.operation')
         for operation in self.browse(cr, uid, picking_id, context=context).pack_operation_ids:
-            pack_op_obj.write(cr, uid, operation.id, {'product_qty': operation.qty_done}, context=context)
+            pack_op_obj.write(cr, uid, operation.id, {'product_qty': operation.qty_done}, context=dict(context, no_recompute=True))
         self.do_transfer(cr, uid, [picking_id], context=context)
         #return id of next picking to work on
         return self.get_next_picking_for_ui(cr, uid, context=context)


### PR DESCRIPTION
Set no_recompute to True
in order to speed up barcode picking UI

This is done for the same reason than
7b306fc17a9e8f3d33df809cbd39af38ab694552
merged through #6754.

The remaining quantities will be computed in the
`do_transfer` method, thanks to the call
`picking_recompute_remaining_quantities`.

There is therefore no need to recompute
the remaining quantities for each pack operation.

Closes #9142
opw-645883