### PR TITLE
[FIX] website: submenu without url

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -41,7 +41,7 @@
     </li>
     <li t-if="submenu.child_id" t-attf-class="dropdown #{
         (submenu.url and submenu.url != '/' and any([request.httprequest.path == child.url.replace('/page/website.', '/page/') for child in submenu.child_id]) or
-         request.httprequest.path == submenu.url.replace('/page/website.', '/page/')) and 'active'
+         (submenu.url and request.httprequest.path == submenu.url.replace('/page/website.', '/page/'))) and 'active'
         }">
         <a class="dropdown-toggle" data-toggle="dropdown" href="#">
             <span t-field="submenu.name"/> <span class="caret" t-ignore="true"></span>


### PR DESCRIPTION
This is not impossible to have a submenu without URL.
The condition to set the menu item as active or not
must therefore take that into account.

opw-652688