### PR TITLE
[FIX] web: radio button display empty value when change record

### DIFF
--- a/addons/web/static/src/js/view_form.js
+++ b/addons/web/static/src/js/view_form.js
@@ -3300,10 +3300,8 @@ instance.web.form.FieldRadio = instance.web.form.AbstractField.extend(instance.w
         var self = this;
         this.$el.toggleClass("oe_readonly", this.get('effective_readonly'));
         this.$("input:checked").prop("checked", false);
-        if (this.get_value()) {
-            this.$("input").filter(function () {return this.value == self.get_value();}).prop("checked", true);
-            this.$(".oe_radio_readonly").text(this.get('value') ? this.get('value')[1] : "");
-        }
+        this.$("input").filter(function () {return this.value == self.get_value();}).prop("checked", true);
+        this.$(".oe_radio_readonly").text(this.get('value') ? this.get('value')[1] : "");
     }
 });
 


### PR DESCRIPTION
When a selection field with widget="radio" is False, the form view display the previews value for this field.

1 - Create a selection field (ex: [("1", "1"), ("2", "2")]), and display it on a form vue.
2 - Go to the form view (all the record have False value for this field).
3 - Change the value of this field for one record.
4 - In readonly mode, all other records now wrongly display this value (still False in DB or when "edit").

#opw-652002