### PR TITLE
[FIX] website: don't unescape translation text node content

### DIFF
--- a/addons/website/static/src/js/website.translator.js
+++ b/addons/website/static/src/js/website.translator.js
@@ -130,7 +130,7 @@
             // TODO: link nodes with same content
             node.className += ' oe_translatable_text';
             node.setAttribute('data-oe-translation-view-id', view_id);
-            var content = node.childNodes[0].data.trim();
+            var content = $(node).html().trim();
             var trans = this.translations.filter(function (t) {
                 return t.res_id === view_id && t.value.trim() === content;
             });
@@ -160,7 +160,7 @@
                 }
                 trans[data.oeTranslationViewId].push({
                     initial_content: self.getInitialContent(this),
-                    new_content: $node.text(),
+                    new_content: $node.html(),
                     translation_id: data.oeTranslationId || null
                 });
             });


### PR DESCRIPTION
When we had things like &nbsp; or &amp; in a text we want to translate,
the translation system would save it unescape (so \xa0 and &).

So in this instance, the traduction would not match the real source
which was not subjected to this unescaping.

opw-653173

note: fix is courtesy of dle (no need to forward port after saas-6)