### PR TITLE
[FIX] account_check_writing: undefined amount

### DIFF
--- a/addons/account_check_writing/report/check_print.py
+++ b/addons/account_check_writing/report/check_print.py
@@ -36,7 +36,7 @@ class report_print_check(report_sxw.rml_parse):
         })
 
     def fill_stars(self, amount):
-        if len(amount) < 100:
+        if amount and len(amount) < 100:
             stars = 100 - len(amount)
             return ' '.join([amount,'*'*stars])
 


### PR DESCRIPTION
In check_writing report, amount is the content of the field amount_to_text that
we can not guarantee has been filled (done in onchange so could be avoided, also
for other languages, etc.)
Instead of potentially failing, double check amount is filled.
cf https://www.odoo.com/groups/59/14976615