### PR TITLE
[FIX] web: csv export newline for text/html field

### DIFF
--- a/addons/base_import/tests/test_cases.py
+++ b/addons/base_import/tests/test_cases.py
@@ -1,5 +1,9 @@
 # -*- encoding: utf-8 -*-
+
+import csv
+import io
 import unittest2
+
 from openerp.tests.common import TransactionCase
 
 from .. import models
@@ -375,6 +379,31 @@ class test_convert_import_data(TransactionCase):
             Import._convert_import_data,
             record, [False, False, False],
             {'quoting': '"', 'separator': ',', 'headers': True,})
+
+    def test_newline_import(self):
+        """
+        Ensure importing keep newlines
+        """
+        Import = self.registry('base_import.import')
+        output = io.BytesIO()
+        writer = csv.writer(output, quoting=csv.QUOTE_ALL)
+
+        data_row = ("\tfoo\n\tbar", " \"hello\" \n\n 'world' ")
+
+        writer.writerow(["name", "Some Value"])
+        writer.writerow(data_row)
+
+
+        id = Import.create(self.cr, self.uid, {
+            'res_model': 'base_import.tests.models.preview',
+            'file': output.getvalue()
+        })
+        record = Import.browse(self.cr, self.uid, id)
+        data, _ = Import._convert_import_data(
+            record, ['name', 'somevalue'],
+            {'quoting': '"', 'separator': ',', 'headers': True,})
+
+        self.assertItemsEqual(data, [data_row])
 
 class test_failures(TransactionCase):
     def test_big_attachments(self):

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1475,8 +1475,7 @@ class CSVExport(ExportFormat, http.Controller):
         for data in rows:
             row = []
             for d in data:
-                if isinstance(d, basestring):
-                    d = d.replace('\n',' ').replace('\t',' ')
+                if isinstance(d, unicode):
                     try:
                         d = d.encode('utf-8')
                     except UnicodeError:


### PR DESCRIPTION
CSV export was added in f146e2a and since then newline were not
exported.

But new line should be allowed if the string is quoted by " characters
which is done in Odoo.

closes #11005
opw-667853