### PR TITLE
[FIX] auth_signup: readonly empty login field on signup

### DIFF
--- a/addons/auth_signup/res_users.py
+++ b/addons/auth_signup/res_users.py
@@ -165,7 +165,7 @@ class res_partner(osv.Model):
         if partner.user_ids:
             res['login'] = partner.user_ids[0].login
         else:
-            res['email'] = partner.email or ''
+            res['login'] = res['email'] = partner.email or ''
         return res
 
 class res_users(osv.Model):


### PR DESCRIPTION
Closes #9367
Fixes #11180