### PR TITLE
[FIX] product_expiry: performance issues due to extra write() call

### DIFF
--- a/addons/product_expiry/product_expiry.py
+++ b/addons/product_expiry/product_expiry.py
@@ -57,16 +57,9 @@ class stock_production_lot(osv.osv):
     }
     # Assign dates according to products data
     def create(self, cr, uid, vals, context=None):
-        newid = super(stock_production_lot, self).create(cr, uid, vals, context=context)
-        obj = self.browse(cr, uid, newid, context=context)
-        towrite = []
-        for f in ('life_date', 'use_date', 'removal_date', 'alert_date'):
-            if not getattr(obj, f):
-                towrite.append(f)
         context = dict(context or {})
-        context['product_id'] = obj.product_id.id
-        self.write(cr, uid, [obj.id], self.default_get(cr, uid, towrite, context=context))
-        return newid
+        context['product_id'] = vals.get('product_id', context.get('default_product_id'))
+        return super(stock_production_lot, self).create(cr, uid, vals, context=context)
 
     _defaults = {
         'life_date': _get_date('life_time'),


### PR DESCRIPTION
When creating thousands of production lots in batch, the
extra call to write() cuts performance in 2, and can be
replaced by an appropriate context when calling super(),
as all the default values are computed correctly.

The only case that could possibly fail is when the product_id
is not passed to the create() call but comes instead from
defaut values (ir.values).
This case is very rare and considered a manual exception
where the expiry dates can be input manually.