### PR TITLE
[FIX] project_issue: partner email

### DIFF
--- a/addons/project_issue/project_issue.py
+++ b/addons/project_issue/project_issue.py
@@ -193,7 +193,7 @@ class project_issue(osv.Model):
         if project_id:
             project = self.pool.get('project.project').browse(cr, uid, project_id, context=context)
             if project and project.partner_id:
-                return {'value': {'partner_id': project.partner_id.id}}
+                return {'value': {'partner_id': project.partner_id.id, 'email_from': project.partner_id.email}}
         return {}
 
     def _get_issue_task(self, cr, uid, ids, context=None):


### PR DESCRIPTION
When a new issue is created, the partner email is not pre-filled.

Fixes #11395
opw-672380