### PR TITLE
[FIX] web: fix layout issue in Chrome 50

### DIFF
--- a/addons/web/static/src/css/chrome50.css
+++ b/addons/web/static/src/css/chrome50.css
@@ -1,0 +1,8 @@
+/* Do not forward port! */
+.oe_leftbar > div > div > div {
+  display: table-cell;
+}
+
+.oe_view_manager > .oe_view_manager_wrapper > div {
+  display: table-cell;
+}

--- a/addons/web/static/src/js/chrome.js
+++ b/addons/web/static/src/js/chrome.js
@@ -1292,6 +1292,14 @@ instance.web.WebClient = instance.web.Client.extend({
             self.action_manager.do_action(self.client_options.action_post_login);
             delete(self.client_options.action_post_login);
         }
+
+        /* Do not forward port! */
+        if ($.browser.chrome) {
+            var chrome_version = $.browser.version.split('.')[0];
+            if (parseInt(chrome_version, 10) >= 50) {
+                openerp.loadCSS('/web/static/src/css/chrome50.css');
+            }
+        }
     },
     update_logo: function() {
         var company = this.session.company_id;


### PR DESCRIPTION
A 100% height is not distributed anymore to the children of a table-row
if they are not themselves table-cell in Chrome 50. This breaks the
indenpendent scrolling of the menu and the view manager.

However, setting the `table-cell` display breaks the layout in Internet
Explorer.

When the webclient is loaded by Chrome 50, we load a stylesheet
forcing a `table-cell` for display.

Seems to be related to https://bugs.chromium.org/p/chromium/issues/detail?id=353580
and https://chromium.googlesource.com/chromium/src.git/+/8876584335b48c99cf8df552ef4d8efebb131041

Related to e1a99192bda1019a50be879cb0baaa72d447956a
Fixes #11629