### PR TITLE
Revert "[FIX] res.currency: allow duplication"

### DIFF
--- a/openerp/addons/base/res/res_currency.py
+++ b/openerp/addons/base/res/res_currency.py
@@ -135,16 +135,6 @@ class res_currency(osv.osv):
         reads = self.read(cr, uid, ids, ['name','symbol'], context=context, load='_classic_write')
         return [(x['id'], tools.ustr(x['name'])) for x in reads]
 
-    def copy(self, cr, uid, id, default=None, context=None):
-        if context is None:
-            context = {}
-        if not default:
-            default = {}
-        default.update(name=_("%s (copy)")
-                       % (self.browse(cr, uid, id, context=context).name))
-        return super(res_currency, self).copy(
-            cr, uid, id, default=default, context=context)
-
     @api.v8
     def round(self, amount):
         """ Return `amount` rounded according to currency `self`. """


### PR DESCRIPTION
This reverts commit d780f9476d43eb4fd25c852dd4e691002f4a6dcf.

Did not work due to the size=3 on name field that strips the code to the first
three letters only (removing the " (copy)" part).
Copying a currency has a few business cases as the rates are not copied.
As can not increase the size of a field in stable, remove the method that had no
effect.

Fixes #11036